### PR TITLE
Update to use v1 ingress and OpenShift route

### DIFF
--- a/manifest_with_ingress.yaml
+++ b/manifest_with_ingress.yaml
@@ -1,0 +1,50 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: telemetry-server-example
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: telemetry-server-example
+  template:
+    metadata:
+      labels:
+        app: telemetry-server-example
+    spec:
+      containers:
+        - name: telemetry-backend
+          image: 'REPLACE IMAGE'
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          imagePullPolicy: Always
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: telemetry-server-example
+spec:
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+  selector:
+    app: telemetry-server-example
+---
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: telemetry-server-example
+spec:
+  rules:
+  - host: 'REPLACE HOST'
+    http:
+      paths:
+      - path: /
+        pathType: Exact
+        backend:
+          service:
+            name: telemetry-server-example
+            port:
+              number: 80

--- a/manifest_with_route.yaml
+++ b/manifest_with_route.yaml
@@ -1,16 +1,16 @@
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: che-workspace-telemetry-example
+  name: telemetry-server-example
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: che-workspace-telemetry-example
+      app: telemetry-server-example
   template:
     metadata:
       labels:
-        app: che-workspace-telemetry-example
+        app: telemetry-server-example
     spec:
       containers:
         - name: telemetry-backend
@@ -23,24 +23,26 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: che-workspace-telemetry-example
+  name: telemetry-server-example
 spec:
   ports:
     - protocol: TCP
       port: 80
       targetPort: 8080
   selector:
-    app: che-workspace-telemetry-example
+    app: telemetry-server-example
 ---
-kind: Ingress
-apiVersion: networking.k8s.io/v1beta1
+kind: Route
+apiVersion: route.openshift.io/v1
 metadata:
-  name: che-workspace-telemetry-example
+  name: telemetry-server-example
 spec:
-  rules:
-  - host: REPLACE HOST
-    http:
-      paths:
-      - backend:
-          serviceName: che-workspace-telemetry-example
-          servicePort: 80
+  host: 'REPLACE HOST'
+  path: /
+  to:
+    kind: Service
+    name: telemetry-server-example
+    weight: 100
+  port:
+    targetPort: 8080
+  wildcardPolicy: None


### PR DESCRIPTION
Removes `manifest.yaml` and adds `manifest_with_ingress.yaml` and `manifest_with_route.yaml`.

Signed-off-by: David Kwon <dakwon@redhat.com>